### PR TITLE
[week5] siyun

### DIFF
--- a/week5/siyun/Minimum_Difference_of_Integer Grid_2.py
+++ b/week5/siyun/Minimum_Difference_of_Integer Grid_2.py
@@ -1,0 +1,46 @@
+import sys
+
+n = int(input())
+grid = [list(map(int, input().split())) for _ in range(n)]
+
+# Please write your code here.
+
+# dp는 최대값만 저장
+INT_MAX=sys.maxsize
+MAX_R= 100
+dp=[[[0] for _ in range(n)]for _ in range (n)]
+
+def init():
+    # dp (0,0) 기준 행, 열은 미리 값 세팅
+    dp[0][0]=grid[0][0]
+    for i in range (1,n):
+        dp[0][i]=max(dp[0][i-1],grid[0][i])
+        dp[i][0]=max(dp[i-1][0],grid[i][0])
+        
+# lower_bound 미만인 모든 셀을 지나갈 수 없는 벽으로 만든다
+def solve(lower_bound):
+    for i in range (n):
+        for j in range (n):
+            if grid[i][j]<lower_bound:
+                grid[i][j]=INT_MAX
+
+    #dp값 업데이트
+    init()
+    for i in range (1,n):
+        for j in range (1,n):
+            # dp의 값 = 해당 위치의 왼쪽 혹은 위쪽 수를 선택했을 때 최대-최소값이 작게 되는 값 선택
+            dp[i][j]=max(min(dp[i][j-1],dp[i-1][j]),grid[i][j])
+
+    # 도착지까지 가는 경로의 최대값 반환
+    return dp[n-1][n-1]
+
+ans=INT_MAX
+# 1~100까지의 lower_bound를 적용해 최대-최소값 풀이
+for i in range (1,MAX_R+1):
+    upper_bound = solve(i)
+    if upper_bound==INT_MAX:
+        continue
+    # 최대-최소값이 더 작은 값으로 갱신
+    ans=min(upper_bound-i,ans)
+
+print(ans)

--- a/week5/siyun/number-of-unique-bst.py
+++ b/week5/siyun/number-of-unique-bst.py
@@ -1,0 +1,40 @@
+n = int(input())
+
+dp=[1]*(n+1)
+# Please write your code here.
+
+#즉, 루트를 k로 고정하면,
+#왼쪽 서브트리로 만들 수 있는 BST의 개수 × 오른쪽 서브트리로 만들 수 있는 BST의 개수가
+#루트를 k로 할 때 만들 수 있는 BST 개수가 되는 것
+# dp[0] = 1 (노드가 없을 때도 하나의 BST로 본다)
+# dp[1] = 1
+# dp[2]=dp[1]*2
+# dp[3]=dp[2]*2+dp[1]
+# dp[4]=dp[3]*2+(dp[1]*dp[2])*2
+# dp[5]=dp[4]*2+(dp[1]*dp[3])*2+(dp[1]*dp[2])*2
+# dp[6]=dp[5]*2+(dp[1]*dp[4])*2+(dp[2]*dp[3])*2
+
+# 점화식
+# dp[i]=(dp[0]*dp[i-1])*2+(dp[1]*dp[i-2])*2+(dp[2]*dp[i-3])*2+...
+# 만약 i가 홀수면 dp[j]와 dp[i-(j+1)]이 같아질때 + dp[j]*dp[j]해줌
+
+for i in range (1, n+1):
+    sum=0
+    for j in range(0,(i//2)+(i%2)):
+        if j==i-(j+1) : sum+=(dp[j]*dp[j])
+        else : sum+=(dp[j]*dp[i-(j+1)])*2
+    dp[i]=sum
+
+print (dp[n])
+
+
+#카탈린 수 점화식은 이건데 대칭되는 부분 중복계산이 들어가게 됨
+#dp[0]=1
+#dp[1]=dp[0]*dp[0]
+#dp[2]=dp[0]*dp[1]+dp[1]*dp[0]
+
+# for i in range(1,n+1):
+#     sum=0
+#     for j in range (i):
+#         sum+=dp[j]*dp[(i-1)-j]
+#     dp[i]=sum

--- a/week5/siyun/selecting_non-overlapping_line_segments_2.py
+++ b/week5/siyun/selecting_non-overlapping_line_segments_2.py
@@ -1,0 +1,21 @@
+n = int(input())
+lines = []
+for _ in range(n):
+    a, b = map(int, input().split())
+    lines.append((a,b))
+
+# Please write your code here.
+dp=[1]*n
+#dp[i] = i번째 선분을 골랐을 때 지금까지 최대로 선택한 선분 갯수
+#정렬 필요함
+
+lines.sort(key =lambda x:x[1])
+
+for i in range(n):
+    for j in range(i):
+        if lines[j][1]<lines[i][0]:
+          #i와 겹치지 않는 j가 여러 개일 수 있고, 그 중 가장 큰 dp[j]를 기반으로 갱신
+            dp[i]=max(dp[i],dp[j]+1)           
+
+
+print(max(dp))


### PR DESCRIPTION
## 📋 내가 푼 문제 링크
[서로 다른 BST 개수 세기](https://www.codetree.ai/ko/trails/complete/curated-cards/challenge-number-of-unique-bst/description)

## ⏱️소요 시간
2h

## ✍️ 수도 코드
루트를 k로 고정하면,
왼쪽 서브트리로 만들 수 있는 BST의 개수 × 오른쪽 서브트리로 만들 수 있는 BST의 개수가
루트를 k로 할 때 만들 수 있는 BST 개수가 되는 것

![image](https://github.com/user-attachments/assets/08f331b8-6098-4afa-9c18-b38316f912bf)


dp[0] = 1 (노드가 없을 때도 하나의 BST로 본다)
dp[1] = dp[0]*dp[0]
dp[2] = (dp[1]*dp[0])*2
dp[3] = (dp[2]*dp[0])*2 + (dp[1]*dp[1])
dp[4] = (dp[3]*dp[0])*2 + (dp[2]*dp[1])*2

점화식
dp[i]=(dp[0]*dp[i-1])*2+(dp[1]*dp[i-2])*2+(dp[2]*dp[i-3])*2+...
만약 i가 홀수면 dp[j]와 dp[i-(j+1)]이 같아질때 + dp[j]*dp[j]해줌

점화식대로 코드 짜면 완성

노드가 없을 때도 하나의 BST로 보는 이유는 ?
1. 없는 서브트리도 하나의 경우(공집합)로 인정해서 1로 센다.
2. 점화식을 간단히 만들기 위해

## 🧐 새롭게 알게된 내용
- 노드 개수가 정해졌을때 이진탐색트리를 만들 수 있는 경우의 수를 루트를 빼서 좌우의 서브BST의 개수를 곱하는 방식으로 구할 수 있다
- 카탈린 수 점화식으로 하면 중복 계산이 들어가되 좀 더 간단하게 코드를 작성할 수 있다.

